### PR TITLE
Upgrades Bashio to v0.3.2

### DIFF
--- a/alpine/aarch64/Dockerfile
+++ b/alpine/aarch64/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/amd64/Dockerfile
+++ b/alpine/amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/armhf/Dockerfile
+++ b/alpine/armhf/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/armv7/Dockerfile
+++ b/alpine/armv7/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/i386/Dockerfile
+++ b/alpine/i386/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apk add --no-cache \
         bash \
         jq \

--- a/raspbian/Dockerfile
+++ b/raspbian/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/aarch64/Dockerfile
+++ b/ubuntu/aarch64/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/amd64/Dockerfile
+++ b/ubuntu/amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/armv7/Dockerfile
+++ b/ubuntu/armv7/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/i386/Dockerfile
+++ b/ubuntu/i386/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.3.1
+ARG BASHIO_VERSION=0.3.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \


### PR DESCRIPTION
Release notes:

<https://github.com/hassio-addons/bashio/releases/tag/v0.3.2>

- :ambulance: Fixes setting supervisor timezone
- :ambulance: Fixes net.wait_for to be compatible with Busybox 1.30+

Mainly, it fixes some compatibility issues with Alpine 3.10.0+.